### PR TITLE
Persist camera extrinsics_noise and light position_noise on UI Save

### DIFF
--- a/Assets/SynthesEyesServer.cs
+++ b/Assets/SynthesEyesServer.cs
@@ -776,20 +776,20 @@ public class SynthesEyesServer : MonoBehaviour{
                 if (i >= lightsArray.Count) continue;
 
                 JSONNode lightNode = lightsArray[i];
-                JSONNode lightExtrinsicsNoise = lightNode["extrinsics_noise"];
+                JSONNode lightPositionNoiseNode = lightNode["position_noise"];
 
-                if (lightExtrinsicsNoise != null)
+                if (lightPositionNoiseNode != null)
                 {
                     Vector3 lightPositionNoise = new Vector3(
-                        lightExtrinsicsNoise["x"] != null ? lightExtrinsicsNoise["x"].AsFloat : 0f,
-                        lightExtrinsicsNoise["y"] != null ? lightExtrinsicsNoise["y"].AsFloat : 0f,
-                        lightExtrinsicsNoise["z"] != null ? lightExtrinsicsNoise["z"].AsFloat : 0f
+                        lightPositionNoiseNode["x"] != null ? lightPositionNoiseNode["x"].AsFloat : 0f,
+                        lightPositionNoiseNode["y"] != null ? lightPositionNoiseNode["y"].AsFloat : 0f,
+                        lightPositionNoiseNode["z"] != null ? lightPositionNoiseNode["z"].AsFloat : 0f
                     );
 
                     Vector3 lightRotationNoise = new Vector3(
-                        lightExtrinsicsNoise["rx"] != null ? lightExtrinsicsNoise["rx"].AsFloat : 0f,
-                        lightExtrinsicsNoise["ry"] != null ? lightExtrinsicsNoise["ry"].AsFloat : 0f,
-                        lightExtrinsicsNoise["rz"] != null ? lightExtrinsicsNoise["rz"].AsFloat : 0f
+                        lightPositionNoiseNode["rx"] != null ? lightPositionNoiseNode["rx"].AsFloat : 0f,
+                        lightPositionNoiseNode["ry"] != null ? lightPositionNoiseNode["ry"].AsFloat : 0f,
+                        lightPositionNoiseNode["rz"] != null ? lightPositionNoiseNode["rz"].AsFloat : 0f
                     );
 
                     float lightOffsetX = GetRandomOffset(lightPositionNoise.x * 100f); 

--- a/Assets/UserInterface/MenuController.cs
+++ b/Assets/UserInterface/MenuController.cs
@@ -1906,18 +1906,18 @@ public class MenuController : MonoBehaviour
             }
             cameraNode.Add("extrinsics", extrinsicsNode);
 
-            // JSONNode extrinsicsNoiseNode = new JSONClass();
-            // if (cameraValues.ContainsKey("ExtrinsicsNoise"))
-            // {
-            //     var extrinsicsNoise = cameraValues["ExtrinsicsNoise"];
-            //     extrinsicsNoiseNode.Add("x", new JSONData(extrinsicsNoise.ContainsKey("x") ? extrinsicsNoise["x"] : 0f));
-            //     extrinsicsNoiseNode.Add("y", new JSONData(extrinsicsNoise.ContainsKey("y") ? extrinsicsNoise["y"] : 0f));
-            //     extrinsicsNoiseNode.Add("z", new JSONData(extrinsicsNoise.ContainsKey("z") ? extrinsicsNoise["z"] : 0f));
-            //     extrinsicsNoiseNode.Add("rx", new JSONData(extrinsicsNoise.ContainsKey("rx") ? extrinsicsNoise["rx"] : 0f));
-            //     extrinsicsNoiseNode.Add("ry", new JSONData(extrinsicsNoise.ContainsKey("ry") ? extrinsicsNoise["ry"] : 0f));
-            //     extrinsicsNoiseNode.Add("rz", new JSONData(extrinsicsNoise.ContainsKey("rz") ? extrinsicsNoise["rz"] : 0f));
-            // }
-            // cameraNode.Add("extrinsics_noise", extrinsicsNoiseNode);
+            JSONNode extrinsicsNoiseNode = new JSONClass();
+            if (cameraValues.ContainsKey("ExtrinsicsNoise"))
+            {
+                var extrinsicsNoise = cameraValues["ExtrinsicsNoise"];
+                extrinsicsNoiseNode.Add("x", new JSONData(extrinsicsNoise.ContainsKey("x") ? extrinsicsNoise["x"] : 0f));
+                extrinsicsNoiseNode.Add("y", new JSONData(extrinsicsNoise.ContainsKey("y") ? extrinsicsNoise["y"] : 0f));
+                extrinsicsNoiseNode.Add("z", new JSONData(extrinsicsNoise.ContainsKey("z") ? extrinsicsNoise["z"] : 0f));
+                extrinsicsNoiseNode.Add("rx", new JSONData(extrinsicsNoise.ContainsKey("rx") ? extrinsicsNoise["rx"] : 0f));
+                extrinsicsNoiseNode.Add("ry", new JSONData(extrinsicsNoise.ContainsKey("ry") ? extrinsicsNoise["ry"] : 0f));
+                extrinsicsNoiseNode.Add("rz", new JSONData(extrinsicsNoise.ContainsKey("rz") ? extrinsicsNoise["rz"] : 0f));
+            }
+            cameraNode.Add("extrinsics_noise", extrinsicsNoiseNode);
 
             camerasArray.Add(cameraNode);
         }
@@ -1953,18 +1953,15 @@ public class MenuController : MonoBehaviour
             }
             lightNode.Add("position", extrinsicsNode);
 
-            JSONNode extrinsicsNoiseNode = new JSONClass();
+            JSONNode positionNoiseNode = new JSONClass();
             if (lightValues.ContainsKey("PositionNoiseGroup"))
             {
-                var extrinsicsNoise = lightValues["PositionNoiseGroup"];
-                // extrinsicsNoiseNode.Add("x", new JSONData(extrinsicsNoise.ContainsKey("x") ? extrinsicsNoise["x"] : 0f));
-                // extrinsicsNoiseNode.Add("y", new JSONData(extrinsicsNoise.ContainsKey("y") ? extrinsicsNoise["y"] : 0f));
-                // extrinsicsNoiseNode.Add("z", new JSONData(extrinsicsNoise.ContainsKey("z") ? extrinsicsNoise["z"] : 0f));
-                // extrinsicsNoiseNode.Add("rx", new JSONData(extrinsicsNoise.ContainsKey("rx") ? extrinsicsNoise["rx"] : 0f));
-                // extrinsicsNoiseNode.Add("ry", new JSONData(extrinsicsNoise.ContainsKey("ry") ? extrinsicsNoise["ry"] : 0f));
-                // extrinsicsNoiseNode.Add("rz", new JSONData(extrinsicsNoise.ContainsKey("rz") ? extrinsicsNoise["rz"] : 0f));
+                var positionNoise = lightValues["PositionNoiseGroup"];
+                positionNoiseNode.Add("x", new JSONData(positionNoise.ContainsKey("x") ? positionNoise["x"] : 0f));
+                positionNoiseNode.Add("y", new JSONData(positionNoise.ContainsKey("y") ? positionNoise["y"] : 0f));
+                positionNoiseNode.Add("z", new JSONData(positionNoise.ContainsKey("z") ? positionNoise["z"] : 0f));
             }
-            // lightNode.Add("position_noise", extrinsicsNoiseNode); // TODO: determine logic for this
+            lightNode.Add("position_noise", positionNoiseNode);
 
             JSONNode propertiesNode = new JSONClass();
             if (lightGroupValues[i].ContainsKey("Properties"))

--- a/Assets/UserInterface/MenuController.cs
+++ b/Assets/UserInterface/MenuController.cs
@@ -779,7 +779,7 @@ public class MenuController : MonoBehaviour
         cameraGroupValues[cameraId]["Intrinsics"] = new Dictionary<string, float>();
         cameraGroupValues[cameraId]["IntrinsicsNoise"] = new Dictionary<string, float>();
         cameraGroupValues[cameraId]["Extrinsics"] = new Dictionary<string, float>();
-        // cameraGroupValues[cameraId]["ExtrinsicsNoise"] = new Dictionary<string, float>();
+        cameraGroupValues[cameraId]["ExtrinsicsNoise"] = new Dictionary<string, float>();
 
         // Initialize Intrinsics and IntrinsicsNoise values
         foreach (string group in new[] { "Intrinsics", "IntrinsicsNoise" })
@@ -793,7 +793,7 @@ public class MenuController : MonoBehaviour
         }
 
         // Initialize Extrinsics and ExtrinsicsNoise values
-        foreach (string group in new[] { "Extrinsics" })
+        foreach (string group in new[] { "Extrinsics", "ExtrinsicsNoise" })
         {
             cameraGroupValues[cameraId][group]["x"] = 0f;
             cameraGroupValues[cameraId][group]["y"] = 0f;
@@ -871,8 +871,8 @@ public class MenuController : MonoBehaviour
                 return "IntrinsicsNoise";
             if (parent.name.Contains("Extrinsics") && !parent.name.Contains("Noise"))
                 return "Extrinsics";
-            // if (parent.name.Contains("ExtrinsicsNoise"))
-            //     return "ExtrinsicsNoise";
+            if (parent.name.Contains("ExtrinsicsNoise"))
+                return "ExtrinsicsNoise";
 
             parent = parent.parent;
         }


### PR DESCRIPTION
## Summary

Fixes two related Bug 2 issues reported by Prof. Gang Luo (Mass Eye and Ear, 2026-04-23/24): camera extrinsics noise and light position noise typed into the settings UI were not being saved to the exported JSON, so configurations didn't round-trip and the runtime never applied those noise channels for non-array-mounted lights.

Two commits, both on the camera/light noise plumbing in `MenuController.cs` and `SynthesEyesServer.cs`. No prefab/scene/UI-layout changes; ProjectSettings untouched.

## What changed

**`8410ffd` — Persist camera extrinsics_noise and light position_noise on UI export**
- `Assets/UserInterface/MenuController.cs:1909-1920` — uncomment the camera `extrinsics_noise` writer block in `SaveConfiguration`. Was wholesale commented out, so the key never appeared in saved JSONs.
- `Assets/UserInterface/MenuController.cs:1956-1964` — uncomment the light `position_noise` writer block. Local var renamed `extrinsicsNoiseNode` → `positionNoiseNode`; x/y/z only, mirroring the existing `position` writer (the upstream `position` writer omits rx/ry/rz; staying parallel).
- `Assets/SynthesEyesServer.cs:776-790` — runtime light noise lookup renamed `lightNode["extrinsics_noise"]` → `lightNode["position_noise"]` so the runtime matches the canonical key used by the README, the upload-side reader, and the (now-uncommented) writer.

**`7c3b0d9` — Wire camera ExtrinsicsNoise UI inputs into the save dictionary**
Without this, the writer in `8410ffd` had nothing to write because the listener wasn't attaching:
- `MenuController.cs:874-875` — `DetermineGroupName` had no branch for `ExtrinsicsNoise`, so input fields inside `ExtrinsicsNoiseGroup` got `groupName = ""` and `InitializeCameraInputFields` skipped attaching their `onValueChanged` listener. Result: typing into camera Extrinsics Noise UI fields was silently dropped on the floor. Branch is now uncommented and consistent with the `IntrinsicsNoise` / `Extrinsics` siblings.
- `MenuController.cs:782` — `cameraGroupValues[cameraId]["ExtrinsicsNoise"]` bucket initialization was commented out. With the listener now firing, the lazy-create at `OnValueChanged` (line 905-908) was logging a noisy `Group 'ExtrinsicsNoise' not found for Camera N` error before recovering. Pre-initializing the bucket silences the log.
- `MenuController.cs:796` — added `"ExtrinsicsNoise"` to the default-zero population loop so the bucket gets six zero fields like `Extrinsics` does.

## Test plan

- [x] **Standalone harness (21/21 PASS)** — pure-C# replay of the post-fix `MenuController.SaveConfiguration` JSON-build loop with synthetic UI dictionary state, asserting `extrinsics_noise.{x,y,z,rx,ry,rz}` and `position_noise.{x,y,z}` blocks are produced with the typed values, plus empty-bucket / counterfactual cases.
- [x] **Unity 6.4 batchmode verifier (32/32 PASS)** — five-layer verifier (`Bug2Verifier.Run`) executed inside Unity 6.4:
  - E1 (a–b): MenuController writers are uncommented in source.
  - E2 (a–b): SynthesEyesServer reads `position_noise`, old key gone.
  - E3 (a–l): post-fix export loop produces correct JSON given synthetic input.
  - E4 (a–f): runtime lookup pattern resolves to the expected `Vector3`.
  - E5 (pre, a–h): a real `Light` GameObject's `transform.position` actually moves within the documented bounds across 200 iterations driven by the project's own `GetRandomOffset` via reflection — i.e., the full per-frame light-noise update path from `SynthesEyesServer.cs:783-803`.
- [x] **Human Save click in Unity 6.4 Editor (10/10 PASS)** — opened the project, pressed Play, clicked Add Camera, typed `0.011/0.022/0.033/1.1/2.2/3.3` into Extrinsics Noise, clicked Add Light (Array Mounted unchecked), typed `0.044/0.055/0.066` into Position Noise, clicked Save. Resulting JSON round-tripped exactly via `verify_saved_json.sh`.
- [x] Build under Unity 6.4 batchmode: 0 CS errors; only pre-existing `FindFirstObjectByType` deprecation warnings remain on lines I didn't touch.

## Reviewer notes

- The runtime key rename for lights is the only behavior change a non-UI consumer can notice. Configs that used to set `extrinsics_noise` on a light (an undocumented key never in the README or the upload-side reader) will need to be renamed to `position_noise`. The shipped `examples/4_camera_demo.json` doesn't use either, so no example update is required.
- Commits are independent — `8410ffd` is sufficient to make exports include the noise blocks; `7c3b0d9` is what makes the camera Extrinsics Noise UI fields actually populate them. Reviewing them in order is recommended.
- **Out of scope for this PR (separate concerns):**
  - The Upload-JSON import path for camera Extrinsics Noise still has a gap at `MenuController.cs:812` (commented-out `cameraInputFields[cameraId]["ExtrinsicsNoise"]` slot). Save is fixed; load isn't. Worth a separate ticket.
  - Bug 1 (pupil size range mislabeled as meters in the README, but the shader's `_PupilSize` is a signed dimensionless UV multiplier) is documented but not fixed here — it needs a product decision on whether to remap the input to mm or update the README to describe the real semantics.