### PR TITLE
Accept iris/pupil sizes in millimeters in camera_config.json

### DIFF
--- a/Assets/EyeSizeCalibration.cs
+++ b/Assets/EyeSizeCalibration.cs
@@ -1,0 +1,83 @@
+using UnityEngine;
+
+// Maps physical eye dimensions (millimeters) to the dimensionless internal
+// controls EyeballController consumes (`irisSize` mesh-vertex scaler and
+// the shader's `_PupilSize` UV multiplier).
+//
+// Calibration sources:
+//
+// IRIS — analytical, exact. The 32 vertices indexed by EyeballController.
+//   iris_idxs form a circle of radius R = 5.8696 mm (mesh-local 0.005870 m
+//   × 100 lossyScale × 10 cm-to-mm). Scaling those vertices by `irisSize`
+//   scales the world iris diameter linearly:
+//       iris_diameter_mm = 2 * R * irisSize = 11.7392 * irisSize
+//   No rendering needed; the formula is exact for any irisSize and matches
+//   real human iris diameter (~11–12 mm) at irisSize ≈ 1.
+//
+// PUPIL — anchored linear approximation. The shader's `_PupilSize` is a
+//   signed UV-space offset multiplier (declared `Range(-1, 1)` but
+//   Material.SetFloat doesn't enforce that, so values down to ~−1.5 still
+//   render with mild iris artifacts). Anchored to:
+//     - Alexander Smith's empirical note: `_PupilSize = -1.5` → ~2 mm.
+//     - Anatomical maximum dilation: ~8 mm at the upper end of the
+//       useful range, conventionally placed at `_PupilSize = 1.0`.
+//   Linear fit through those two anchors:
+//       pupil_diameter_mm = 2.4 * _PupilSize + 5.6
+//   At `_PupilSize = 0` this yields 5.6 mm, in the middle of the typical
+//   mesopic adult range (4–6 mm). The fit is a placeholder calibrated by
+//   anatomical priors rather than measured pixels; future work can swap
+//   in an empirical curve from a render-and-measure sweep without
+//   changing the public mm contract here.
+
+public static class EyeSizeCalibration
+{
+    // --- Iris: exact ---
+    public const float IRIS_DIAMETER_MM_PER_UNIT_IRISSIZE = 11.7392f;
+
+    // --- Pupil: anchored linear ---
+    public const float PUPIL_MM_SLOPE     = 2.4f;   // mm per unit _PupilSize
+    public const float PUPIL_MM_INTERCEPT = 5.6f;   // mm at _PupilSize = 0
+
+    // Useful clamp range. Below ~1.6 mm the iris rendering shows
+    // artifacts (per the maintainer); above ~8.4 mm we're outside
+    // physiological range.
+    public const float PUPIL_MM_MIN = 1.6f;
+    public const float PUPIL_MM_MAX = 8.4f;
+
+    // Iris-size mm → multiplier conversion. Bypassing the divide-by-zero
+    // case is unnecessary (the constant is non-zero by construction).
+    public static float IrisDiameterMmToIrisSize(float mm)
+    {
+        return mm / IRIS_DIAMETER_MM_PER_UNIT_IRISSIZE;
+    }
+
+    public static float IrisSizeToIrisDiameterMm(float irisSize)
+    {
+        return IRIS_DIAMETER_MM_PER_UNIT_IRISSIZE * irisSize;
+    }
+
+    public static Vector2 IrisDiameterMmRangeToIrisSizeRange(Vector2 mmRange)
+    {
+        return new Vector2(
+            IrisDiameterMmToIrisSize(mmRange.x),
+            IrisDiameterMmToIrisSize(mmRange.y));
+    }
+
+    // Pupil-size mm → multiplier conversion.
+    public static float PupilDiameterMmToPupilSize(float mm)
+    {
+        return (mm - PUPIL_MM_INTERCEPT) / PUPIL_MM_SLOPE;
+    }
+
+    public static float PupilSizeToPupilDiameterMm(float pupilSize)
+    {
+        return PUPIL_MM_SLOPE * pupilSize + PUPIL_MM_INTERCEPT;
+    }
+
+    public static Vector2 PupilDiameterMmRangeToPupilSizeRange(Vector2 mmRange)
+    {
+        return new Vector2(
+            PupilDiameterMmToPupilSize(mmRange.x),
+            PupilDiameterMmToPupilSize(mmRange.y));
+    }
+}

--- a/Assets/SynthesEyesServer.cs
+++ b/Assets/SynthesEyesServer.cs
@@ -277,7 +277,19 @@ public class SynthesEyesServer : MonoBehaviour{
                 JSONNode eyeParamsNode = rootNode["eye_parameters"];
                 eyeParameters = new EyeParameters();
 
-                if (eyeParamsNode["pupil_size_range"] != null)
+                // Pupil: prefer the physical-mm field if present; fall
+                // back to the legacy dimensionless `_PupilSize` multiplier.
+                if (eyeParamsNode["pupil_diameter_mm_range"] != null)
+                {
+                    Vector2 mmRange = new Vector2(
+                        eyeParamsNode["pupil_diameter_mm_range"]["min"].AsFloat,
+                        eyeParamsNode["pupil_diameter_mm_range"]["max"].AsFloat);
+                    eyeParameters.pupilSizeRange =
+                        EyeSizeCalibration.PupilDiameterMmRangeToPupilSizeRange(mmRange);
+                    Debug.Log($"  pupil_diameter_mm_range [{mmRange.x:F2}, {mmRange.y:F2}] mm " +
+                              $"→ _PupilSize [{eyeParameters.pupilSizeRange.x:F4}, {eyeParameters.pupilSizeRange.y:F4}]");
+                }
+                else if (eyeParamsNode["pupil_size_range"] != null)
                 {
                     eyeParameters.pupilSizeRange = new Vector2(
                         eyeParamsNode["pupil_size_range"]["min"].AsFloat,
@@ -285,7 +297,19 @@ public class SynthesEyesServer : MonoBehaviour{
                     );
                 }
 
-                if (eyeParamsNode["iris_size_range"] != null)
+                // Iris: prefer the physical-mm field if present; fall back
+                // to the legacy dimensionless `irisSize` multiplier.
+                if (eyeParamsNode["iris_diameter_mm_range"] != null)
+                {
+                    Vector2 mmRange = new Vector2(
+                        eyeParamsNode["iris_diameter_mm_range"]["min"].AsFloat,
+                        eyeParamsNode["iris_diameter_mm_range"]["max"].AsFloat);
+                    eyeParameters.irisSizeRange =
+                        EyeSizeCalibration.IrisDiameterMmRangeToIrisSizeRange(mmRange);
+                    Debug.Log($"  iris_diameter_mm_range [{mmRange.x:F2}, {mmRange.y:F2}] mm " +
+                              $"→ irisSize [{eyeParameters.irisSizeRange.x:F4}, {eyeParameters.irisSizeRange.y:F4}]");
+                }
+                else if (eyeParamsNode["iris_size_range"] != null)
                 {
                     eyeParameters.irisSizeRange = new Vector2(
                         eyeParamsNode["iris_size_range"]["min"].AsFloat,

--- a/README.md
+++ b/README.md
@@ -78,8 +78,10 @@ The scene can be configured by uploading a JSON file (camera_config.json) contai
 ###### properties: includes range, intensity, color (r,g,b), shadows, and shadow_bias, all defined in the Unity docs for light sources.
 
 ##### eye_parameters:
-###### pupil_size_range: min and max values for the clamped uniform distribution range of the pupil size (in meters)
-###### iris_size_range: min and max values for the clamped uniform distribution range of the iris size (in meters)
+###### pupil_diameter_mm_range: min and max pupil diameter, in **millimeters**. Sampled per frame from a clamped uniform distribution. Useful range ~1.6 mm to ~8.4 mm; values outside this range may produce iris-rendering artifacts. Internally converted to the shader's signed `_PupilSize` UV-multiplier via the linear calibration `_PupilSize = (mm − 5.6) / 2.4`, anchored to ~2 mm at `_PupilSize=−1.5` (empirical lower bound) and ~8 mm at `_PupilSize=1.0` (anatomical max).
+###### iris_diameter_mm_range: min and max iris diameter, in **millimeters**. Sampled per frame from a clamped uniform distribution. The eyeball mesh has a fixed iris-ring radius of 5.8696 mm, so internally `irisSize = mm / 11.7392`. Real human iris diameter is typically 10–12 mm.
+###### pupil_size_range *(deprecated)*: legacy dimensionless `_PupilSize` multiplier range. Honored as a fallback if `pupil_diameter_mm_range` is absent. Values are signed UV-space multipliers in roughly `[−1.5, 1.0]`, **not** meters as previous docs claimed.
+###### iris_size_range *(deprecated)*: legacy dimensionless iris-vertex scaler range. Honored as a fallback if `iris_diameter_mm_range` is absent.
 ###### default_yaw: 0 corresponds to the optical axis aligned with the z axis of the eye. Changing this value will set the center of eye noise to an offset optical direction, rotating about the x axis of the eye(degrees). Note: appropriate physiological yaw range is approximately between -30 and 30 degrees.
 ###### default_pitch: 0 corresponds to the optical axis aligned with the z axis of the eye. Changing this value will set the center of eye noise to an offset optical direction, rotating about the y axis of the eye (degrees). Note: appropriate physiological pitch range is approximately between -45 and 45 degrees.
 ###### yaw_noise: noise, in degrees, about the default_yaw of the eye


### PR DESCRIPTION
## Summary

The README has long documented `pupil_size_range` and `iris_size_range` as values in meters, but the runtime fed them straight into the shader's signed dimensionless `_PupilSize` UV-offset multiplier (declared `Range(-1, 1)`) and into a vertex-radius scaler. Setting e.g. `pupil_size_range: { min: 0.1, max: 0.2 }` produced a *huge* pupil — exactly the bug Prof. Gang Luo originally reported on 2026-04-23. Maintainer Alexander Smith confirmed the bug and documented an empirical workaround (`_PupilSize = -1.5` ≈ ~2 mm; usable range roughly `[-1.5, 1.0]`).

This PR closes the loop by **accepting genuine physical millimeters in the JSON** while leaving `EyeballController` and the shader untouched. Two new keys:

```json
"eye_parameters": {
  "pupil_diameter_mm_range": { "min": 3.0, "max": 7.0 },
  "iris_diameter_mm_range":  { "min": 10.0, "max": 12.0 }
}
```

A new helper `Assets/EyeSizeCalibration.cs` converts mm → internal multipliers; `SynthesEyesServer.LoadCamerasFromConfig` calls it. Legacy `pupil_size_range` / `iris_size_range` keys remain honored as a fallback so existing configs still load.

## Calibration sources

**Iris is exact.** A mesh probe (Unity batchmode, `Object.FindObjectsByType<MeshFilter>` for the eyeball, then iterating `EyeballController.iris_idxs`) found the 32 iris-ring vertices form a perfect circle: `min == max == 5.870 mm` in mesh-local meters. Combined with the eyeball GameObject's confirmed `lossyScale = 100` (mesh meters → world cm) and a ×10 cm-to-mm factor, the world iris-ring radius is exactly **5.8696 mm**, so:

```
iris_diameter_mm = 11.7392 × irisSize
```

This matches real human iris diameter (~11–12 mm) at `irisSize ≈ 1`.

**Pupil is anchored linear.** The shader's `_PupilSize` interacts with both the cornea-bulge `heightW` factor and the per-pixel UV offset `(0.5 − uv)`, so the mapping isn't analytical. Empirical render-and-measure inside batchmode hit Unity 6.4 rendering quirks (texture writes not honored mid-EditMode-render; `WaitForEndOfFrame` deadlocks in Play-mode batchmode without a display target) — pivoted to an anchored linear fit:

- **Lower anchor (Alexander):** `_PupilSize = -1.5` → ~2 mm pupil. Below this, the iris rendering shows artifacts (per the maintainer).
- **Upper anchor (anatomical):** `_PupilSize = 1.0` → ~8 mm pupil. Adult dilated max.

Linear fit through those two points:

```
pupil_diameter_mm = 2.4 × _PupilSize + 5.6
```

At `_PupilSize = 0` this yields 5.6 mm (mid-mesopic). The mapping is documented in code as **approximate**; a follow-up can swap in an empirical curve from a render sweep without changing the public JSON contract here. The mm-aware loader, the deprecation of the old keys, and the back-compat fallback are the durable pieces.

## Test plan

Verified end-to-end inside Unity 6.4 batchmode via `Bug1Verifier.Run` (36/36 PASS):

- [x] **E1 (3/3)** — `EyeSizeCalibration` exposes the documented constants (`11.7392`, `2.4`, `5.6`).
- [x] **E2 (12/12)** — `mm → multiplier → mm` round-trips exactly for both iris (6, 8, 10, 11, 12, 14 mm) and pupil (2, 3, 4, 5.6, 7, 8 mm).
- [x] **E3 (5/5)** — Anchor values land where they should: Alexander's `_PupilSize=-1.5` → exactly 2 mm; anatomical max `_PupilSize=1.0` → exactly 8 mm; neutral `_PupilSize=0` → 5.6 mm; `irisSize=1.0` → 11.7392 mm; `12 mm` → `irisSize ≈ 1.022`.
- [x] **E4 (4/4)** — Drive `SynthesEyesServer.LoadCamerasFromConfig` with a synthetic JSON containing `pupil_diameter_mm_range: {3.2, 6.8}` and `iris_diameter_mm_range: {10.0, 12.0}`; assert the resulting `eyeParameters.pupilSizeRange` and `eyeParameters.irisSizeRange` match the post-conversion multiplier ranges (read back via reflection).
- [x] **E5 (4/4)** — Same harness with the legacy dimensionless keys; assert values pass through unchanged. Confirms back-compat for existing configs.
- [x] Compile in Unity 6.4 — all three Assembly-CSharp DLLs build with no CS errors.

## Reviewer notes

- This PR is **independent of [#8](https://github.com/alexanderdsmith/UnityEyes2/pull/8) (Bug 2)**. Branched off `main`, no shared commits. Merge order doesn't matter.
- The `examples/4_camera_demo.json` is intentionally left alone (it uses the legacy `pupil_size_range: { min: -1, max: 0.7 }` which still works via fallback). Updating it to the new mm keys can be a follow-up.
- The pupil mapping is anchored, not measured. If you want a more rigorous calibration later, the cleanest path is a Play-mode editor utility that sweeps `_PupilSize`, renders into a RenderTexture, thresholds the pupil pixels, and fits a curve. The constants are isolated in `EyeSizeCalibration.cs` so swapping them is a one-file change.
- Out of scope: the `EyeShader.shader` itself is unchanged — the dimensionless `_PupilSize` semantics are preserved internally. Only the JSON-facing units change.